### PR TITLE
Use SSLContext#sigalgs instead of SSLContext#client_sigalgs.

### DIFF
--- a/connect.rb
+++ b/connect.rb
@@ -23,7 +23,8 @@ begin
   when "mldsa"
     nil
   when "rsa"
-    ctx.client_sigalgs = "rsa_pss_pss_sha256:rsa_pss_rsae_sha256"
+    ctx.sigalgs = "rsa_pss_pss_sha256:rsa_pss_rsae_sha256"
+    # ctx.client_sigalgs = "rsa_pss_pss_sha256:rsa_pss_rsae_sha256"
     # ctx.client_sigalgs = "RSA-PSS+SHA256"
   else
     print_usage


### PR DESCRIPTION
It seems that the `SSLContext#sigalgs` is equivalent from the `openssl s_client -sigalgs` option.

```
$ ./pqc.sh start-dual-cert-server
...
Shared ciphers:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-CHACHA20-POLY1305:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-SHA384:DHE-RSA-AES256-SHA256:ECDHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA:DHE-RSA-AES256-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES128-SHA:AES256-GCM-SHA384:AES128-GCM-SHA256:AES256-SHA256:AES128-SHA256:AES256-SHA:AES128-SHA
Signature Algorithms: rsa_pss_pss_sha256:RSA-PSS+SHA256
Shared Signature Algorithms: rsa_pss_pss_sha256:RSA-PSS+SHA256
...
```